### PR TITLE
Fix incorrect proxy config

### DIFF
--- a/client/vite.config.js
+++ b/client/vite.config.js
@@ -8,6 +8,7 @@ export default defineConfig({
     proxy: {
       "/api": {
         target: "http://0.0.0.0:5100",
+        rewrite: path => path.replace(/^\/api/, ''),
         configure: (proxy, _options) => {
           proxy.on('error', (err, _req, _res) => {
             console.log('proxy error', err);


### PR DESCRIPTION
Currently, the vite proxy configuration is making requests to `http://localhost:5000` instead of `http://0.0.0.0:5100`. By adding the `rewrite` option parameter, this PR resolves that issue and properly makes requests to the server.