### PR TITLE
[Closes #122] Update enum format function to handle underscores

### DIFF
--- a/client/package.json
+++ b/client/package.json
@@ -24,6 +24,7 @@
     "@tanstack/react-query": "^5.51.23",
     "dayjs": "^1.11.13",
     "http-status-codes": "^2.3.0",
+    "inflection": "^3.0.0",
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-imask": "^7.6.1",

--- a/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
+++ b/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
@@ -4,6 +4,8 @@ import { Accordion, TextInput, Select, InputBase } from '@mantine/core';
 import { DateInput } from '@mantine/dates';
 import { IconCircleCheck } from '@tabler/icons-react';
 import { IMaskInput } from 'react-imask';
+import { humanize } from 'inflection';
+
 import MedicalDataSearch from './inputs/MedicalDataSearch';
 import HealthcareChoicesSearch from './inputs/HealthcareChoicesSearch';
 
@@ -32,18 +34,6 @@ const FORM_SELECT_ENUM_VALUES = {
   relationship: ['SPOUSE', 'PARENT', 'CHILD', 'SIBLING', 'OTHER', 'UNKNOWN'],
   codeStatus: ['COMFORT', 'DNR', 'DNI', 'DNR_DNI', 'FULL'],
 };
-
-/**
- * Converts a string to title case and removes underscores
- * @param {string} string
- * @returns {string}
- */
-function formatEnum(string) {
-  return string
-    .split('_')
-    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
-    .join(' ');
-}
 
 /**
  *  Patient Registration Accordion component
@@ -100,7 +90,7 @@ export default function PatientRegistrationAccordion({
               withAsterisk
               data={FORM_SELECT_ENUM_VALUES.gender.map((value) => ({
                 value,
-                label: formatEnum(value),
+                label: humanize(value),
               }))}
               searchable
               key={form.key('patientData.gender')}
@@ -112,7 +102,7 @@ export default function PatientRegistrationAccordion({
               withAsterisk
               data={FORM_SELECT_ENUM_VALUES.language.map((value) => ({
                 value,
-                label: formatEnum(value),
+                label: humanize(value),
               }))}
               searchable
               key={form.key('patientData.language')}
@@ -176,7 +166,7 @@ export default function PatientRegistrationAccordion({
               placeholder="Select Relationship"
               data={FORM_SELECT_ENUM_VALUES.relationship.map((value) => ({
                 value,
-                label: formatEnum(value),
+                label: humanize(value),
               }))}
               searchable
               key={form.key('contactData.relationship')}
@@ -240,7 +230,7 @@ export default function PatientRegistrationAccordion({
               placeholder="Select Code Status"
               data={FORM_SELECT_ENUM_VALUES.codeStatus.map((value) => ({
                 value,
-                label: formatEnum(value),
+                label: humanize(value),
               }))}
               searchable
               key={form.key('codeStatus')}

--- a/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
+++ b/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
@@ -34,12 +34,15 @@ const FORM_SELECT_ENUM_VALUES = {
 };
 
 /**
- * Converts a string to title case
+ * Converts a string to title case and removes underscores
  * @param {string} string
  * @returns {string}
  */
-function toTitleCase(string) {
-  return string.charAt(0).toUpperCase() + string.slice(1).toLowerCase();
+function formatEnum(string) {
+  return string
+    .split('_')
+    .map((word) => word.charAt(0).toUpperCase() + word.slice(1).toLowerCase())
+    .join(' ');
 }
 
 /**
@@ -97,7 +100,7 @@ export default function PatientRegistrationAccordion({
               withAsterisk
               data={FORM_SELECT_ENUM_VALUES.gender.map((value) => ({
                 value,
-                label: toTitleCase(value),
+                label: formatEnum(value),
               }))}
               searchable
               key={form.key('patientData.gender')}
@@ -109,7 +112,7 @@ export default function PatientRegistrationAccordion({
               withAsterisk
               data={FORM_SELECT_ENUM_VALUES.language.map((value) => ({
                 value,
-                label: toTitleCase(value),
+                label: formatEnum(value),
               }))}
               searchable
               key={form.key('patientData.language')}
@@ -173,7 +176,7 @@ export default function PatientRegistrationAccordion({
               placeholder="Select Relationship"
               data={FORM_SELECT_ENUM_VALUES.relationship.map((value) => ({
                 value,
-                label: toTitleCase(value),
+                label: formatEnum(value),
               }))}
               searchable
               key={form.key('contactData.relationship')}
@@ -237,7 +240,7 @@ export default function PatientRegistrationAccordion({
               placeholder="Select Code Status"
               data={FORM_SELECT_ENUM_VALUES.codeStatus.map((value) => ({
                 value,
-                label: toTitleCase(value),
+                label: formatEnum(value),
               }))}
               searchable
               key={form.key('codeStatus')}

--- a/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
+++ b/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
@@ -14,8 +14,8 @@ import classes from './PatientRegistationAccordion.module.css';
 const PatientRegistrationAccordionProps = {
   form: PropTypes.object.isRequired,
   initialMedicalData: PropTypes.object,
-  initialHospitalData: PropTypes.object,
-  initialPhysicianData: PropTypes.object,
+  initialHospitalData: PropTypes.string,
+  initialPhysicianData: PropTypes.string,
   openedSection: PropTypes.string,
   showCheck: PropTypes.object.isRequired,
   handleAccordionChange: PropTypes.func.isRequired,

--- a/client/src/pages/patients/register/inputs/HealthcareChoicesSearch.jsx
+++ b/client/src/pages/patients/register/inputs/HealthcareChoicesSearch.jsx
@@ -12,7 +12,7 @@ import LifelineAPI from '../../LifelineAPI.js';
 const healthcareChoicesSearchProps = {
   form: PropTypes.object.isRequired,
   choice: PropTypes.string.isRequired,
-  initialData: PropTypes.object,
+  initialData: PropTypes.string,
 };
 
 /**

--- a/package-lock.json
+++ b/package-lock.json
@@ -28,6 +28,7 @@
         "@tanstack/react-query": "^5.51.23",
         "dayjs": "^1.11.13",
         "http-status-codes": "^2.3.0",
+        "inflection": "^3.0.0",
         "react": "^18.3.1",
         "react-dom": "^18.3.1",
         "react-imask": "^7.6.1",
@@ -8155,6 +8156,15 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/inflection": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/inflection/-/inflection-3.0.0.tgz",
+      "integrity": "sha512-1zEJU1l19SgJlmwqsEyFTbScw/tkMHFenUo//Y0i+XEP83gDFdMvPizAD/WGcE+l1ku12PcTVHQhO6g5E0UCMw==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "node_modules/inflight": {


### PR DESCRIPTION
Closes #122.

This PR updates the enum formatting function to properly handle underscores, so `TRANS_MALE` becomes `Trans Male` instead of `Trans_male`. I originally used a custom solution, but to better future-proof the codebase for string transformations (e.g. formatting a server message in the future), I switched to the suggested [inflection library](https://www.npmjs.com/package/inflection).

Before:
<img width="900" alt="image" src="https://github.com/user-attachments/assets/02a93732-c416-469e-8159-0a887118a910">

After:
<img width="900" alt="image" src="https://github.com/user-attachments/assets/aeecf4d0-59ff-49d4-8e44-c8d245598a99">

