### PR TITLE
[Closes #143] Resolve `defaultProp` and required prop warnings

### DIFF
--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -146,13 +146,17 @@ function App() {
             <Route
               path="/patients/register/:patientId"
               element={
-                <ProtectedRoute
+                user ? (
+                  <ProtectedRoute
                   role={user?.role}
                   restrictedRoles={['FIRST_RESPONDER']}
                   message={'Patient does not exist.'}
-                >
+                  >
                   <PatientRegistration />
                 </ProtectedRoute>
+                ) : (
+                  <Loader />
+                )
               }
             />
 

--- a/client/src/App.jsx
+++ b/client/src/App.jsx
@@ -148,12 +148,12 @@ function App() {
               element={
                 user ? (
                   <ProtectedRoute
-                  role={user?.role}
-                  restrictedRoles={['FIRST_RESPONDER']}
-                  message={'Patient does not exist.'}
+                    role={user?.role}
+                    restrictedRoles={['FIRST_RESPONDER']}
+                    message={'Patient does not exist.'}
                   >
-                  <PatientRegistration />
-                </ProtectedRoute>
+                    <PatientRegistration />
+                  </ProtectedRoute>
                 ) : (
                   <Loader />
                 )

--- a/client/src/stories/Header/Header.jsx
+++ b/client/src/stories/Header/Header.jsx
@@ -18,7 +18,7 @@ import { Sidebar } from '../../components/Sidebar/Sidebar';
  * Buttons for logged out buttons
  * @param {PropTypes.InferProps<typeof headerProps>} props
  */
-export function Header({ user }) {
+export function Header({ user = null }) {
   const [drawerOpened, { toggle: toggleDrawer, close: closeDrawer }] =
     useDisclosure(false);
 
@@ -74,9 +74,6 @@ const headerProps = {
 };
 
 Header.propTypes = headerProps;
-Header.defaultProps = {
-  user: null,
-};
 
 const loggedOutButtonsProps = {};
 


### PR DESCRIPTION
Fixes #143.

There were two Chrome console warnings:

- Using `defaultProps` in the `Header.jsx` component
- Missing prop value despite it being required for the `ProtectedRoute` component

To resolve these warnings:

- `defaultProps` was removed and a default value is used in the `Header.jsx` component
- Utilized conditional rendering to show a `Loader` component while user context is being updated