### PR TITLE
[Closes #181] Create a reusable `Table` component

### DIFF
--- a/client/src/components/DataTable/DataTable.jsx
+++ b/client/src/components/DataTable/DataTable.jsx
@@ -22,7 +22,7 @@ const dataTableProps = {
  * Reusable DataTable component
  * @param {PropTypes.InferProps<typeof dataTableProps>} props
  */
-export default function DataTable({
+export default function DataTable ({
   headers,
   data = [],
   renderRow,
@@ -36,11 +36,11 @@ export default function DataTable({
 
   return (
     <Paper withBorder className={classes.tableWrapper}>
-      <Table.ScrollContainer minWidth={500} type="native">
+      <Table.ScrollContainer minWidth={500} type='native'>
         <Table
           stickyHeader
           highlightOnHover
-          verticalSpacing="lg"
+          verticalSpacing='lg'
           classNames={{ table: classes.table }}
         >
           <Table.Thead>

--- a/client/src/components/DataTable/DataTable.jsx
+++ b/client/src/components/DataTable/DataTable.jsx
@@ -1,0 +1,62 @@
+import PropTypes from 'prop-types';
+import { Paper, Table } from '@mantine/core';
+import classes from './DataTable.module.css';
+
+const dataTableProps = {
+  headers: PropTypes.arrayOf(
+    PropTypes.shape({
+      key: PropTypes.string.isRequired,
+      text: PropTypes.node,
+    })
+  ).isRequired,
+  data: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    })
+  ),
+  renderRow: PropTypes.func.isRequired,
+  emptyStateMessage: PropTypes.string,
+};
+
+/**
+ * Reusable DataTable component
+ * @param {PropTypes.InferProps<typeof dataTableProps>} props
+ */
+export default function DataTable({
+  headers,
+  data = [],
+  renderRow,
+  emptyStateMessage = 'No data found.',
+}) {
+  const emptyStateRow = (
+    <Table.Tr>
+      <Table.Td colSpan={headers.length}>{emptyStateMessage}</Table.Td>
+    </Table.Tr>
+  );
+
+  return (
+    <Paper withBorder className={classes.tableWrapper}>
+      <Table.ScrollContainer minWidth={500} type="native">
+        <Table
+          stickyHeader
+          highlightOnHover
+          verticalSpacing="lg"
+          classNames={{ table: classes.table }}
+        >
+          <Table.Thead>
+            <Table.Tr>
+              {headers.map((header) => (
+                <Table.Th key={header.key}>{header.text}</Table.Th>
+              ))}
+            </Table.Tr>
+          </Table.Thead>
+          <Table.Tbody>
+            {data.length > 0 ? data.map(renderRow) : emptyStateRow}
+          </Table.Tbody>
+        </Table>
+      </Table.ScrollContainer>
+    </Paper>
+  );
+}
+
+DataTable.propTypes = dataTableProps;

--- a/client/src/components/DataTable/DataTable.module.css
+++ b/client/src/components/DataTable/DataTable.module.css
@@ -1,0 +1,8 @@
+.tableWrapper {
+  margin-bottom: var(--mantine-spacing-xs);
+}
+
+.table {
+  border-radius: 7px;
+  overflow: hidden;
+} 

--- a/client/src/components/DataTable/TableMenu.jsx
+++ b/client/src/components/DataTable/TableMenu.jsx
@@ -41,6 +41,8 @@ export default function TableMenu ({ menuItems }) {
             <Menu.Item
               key={item.label}
               leftSection={item.icon}
+              // onChange is a Mantine prop for the Menu.Item component, neostandard improperly considers it a react event handler
+              // eslint-disable-next-line react/jsx-handler-names
               onClick={item.onClick}
               to={item.to}
               color={item.color}

--- a/client/src/components/DataTable/TableMenu.jsx
+++ b/client/src/components/DataTable/TableMenu.jsx
@@ -21,11 +21,11 @@ const tableMenuProps = {
  * Reusable table menu component
  * @param {PropTypes.InferProps<typeof tableMenuProps>} props
  */
-export default function TableMenu({ menuItems }) {
+export default function TableMenu ({ menuItems }) {
   return (
-    <Menu shadow="md">
+    <Menu shadow='md'>
       <Menu.Target>
-        <ActionIcon variant="subtle" color="gray">
+        <ActionIcon variant='subtle' color='gray'>
           <IconDotsVertical size={18} />
         </ActionIcon>
       </Menu.Target>
@@ -55,4 +55,4 @@ export default function TableMenu({ menuItems }) {
   );
 }
 
-TableMenu.propTypes = tableMenuProps; 
+TableMenu.propTypes = tableMenuProps;

--- a/client/src/components/DataTable/TableMenu.jsx
+++ b/client/src/components/DataTable/TableMenu.jsx
@@ -1,0 +1,58 @@
+import PropTypes from 'prop-types';
+import { Menu, ActionIcon } from '@mantine/core';
+import { TbDotsVertical as IconDotsVertical } from 'react-icons/tb';
+
+const tableMenuProps = {
+  menuItems: PropTypes.arrayOf(
+    PropTypes.shape({
+      icon: PropTypes.node.isRequired,
+      label: PropTypes.string.isRequired,
+      onClick: PropTypes.func,
+      to: PropTypes.string,
+      color: PropTypes.string,
+      component: PropTypes.elementType,
+      divider: PropTypes.bool,
+      isLabel: PropTypes.bool,
+    })
+  ).isRequired,
+};
+
+/**
+ * Reusable table menu component
+ * @param {PropTypes.InferProps<typeof tableMenuProps>} props
+ */
+export default function TableMenu({ menuItems }) {
+  return (
+    <Menu shadow="md">
+      <Menu.Target>
+        <ActionIcon variant="subtle" color="gray">
+          <IconDotsVertical size={18} />
+        </ActionIcon>
+      </Menu.Target>
+      <Menu.Dropdown>
+        {menuItems.map((item, index) => {
+          if (item.divider) {
+            return <Menu.Divider key={`divider-${index}`} />;
+          }
+          if (item.isLabel) {
+            return <Menu.Label key={`label-${index}`}>{item.label}</Menu.Label>;
+          }
+          return (
+            <Menu.Item
+              key={item.label}
+              leftSection={item.icon}
+              onClick={item.onClick}
+              to={item.to}
+              color={item.color}
+              component={item.component}
+            >
+              {item.label}
+            </Menu.Item>
+          );
+        })}
+      </Menu.Dropdown>
+    </Menu>
+  );
+}
+
+TableMenu.propTypes = tableMenuProps; 

--- a/client/src/components/DataTable/TableMenu.jsx
+++ b/client/src/components/DataTable/TableMenu.jsx
@@ -41,7 +41,7 @@ export default function TableMenu ({ menuItems }) {
             <Menu.Item
               key={item.label}
               leftSection={item.icon}
-              // onChange is a Mantine prop for the Menu.Item component, neostandard improperly considers it a react event handler
+              // onClick is a Mantine prop for the Menu.Item component, neostandard improperly considers it a react event handler
               // eslint-disable-next-line react/jsx-handler-names
               onClick={item.onClick}
               to={item.to}

--- a/client/src/components/UsersDataTable/DataTableMenu.jsx
+++ b/client/src/components/UsersDataTable/DataTableMenu.jsx
@@ -11,7 +11,7 @@ import TableMenu from '../DataTable/TableMenu';
 /**
  *
  */
-export function DataTableMenu() {
+export function DataTableMenu () {
   const menuItems = [
     {
       isLabel: true,
@@ -20,12 +20,12 @@ export function DataTableMenu() {
     {
       icon: <IconSettings style={{ width: rem(14), height: rem(14) }} />,
       label: 'Account',
-      onClick: () => {/* implement account action */},
+      onClick: () => { /* implement account action */ },
     },
     {
       icon: <IconMessageCircle style={{ width: rem(14), height: rem(14) }} />,
       label: 'Message',
-      onClick: () => {/* implement message action */},
+      onClick: () => { /* implement message action */ },
     },
     {
       divider: true,
@@ -37,13 +37,13 @@ export function DataTableMenu() {
     {
       icon: <IconArrowsLeftRight style={{ width: rem(14), height: rem(14) }} />,
       label: 'Update role',
-      onClick: () => {/* implement role update action */},
+      onClick: () => { /* implement role update action */ },
     },
     {
       icon: <IconTrash style={{ width: rem(14), height: rem(14) }} />,
       label: 'Delete account',
       color: 'red',
-      onClick: () => {/* implement delete action */},
+      onClick: () => { /* implement delete action */ },
     },
   ];
 

--- a/client/src/components/UsersDataTable/DataTableMenu.jsx
+++ b/client/src/components/UsersDataTable/DataTableMenu.jsx
@@ -1,61 +1,51 @@
 import React from 'react';
-import { Menu, rem, ActionIcon } from '@mantine/core';
+import { rem } from '@mantine/core';
 import {
   TbSettings as IconSettings,
   TbMessageCircle as IconMessageCircle,
   TbTrash as IconTrash,
   TbArrowsLeftRight as IconArrowsLeftRight,
-  TbDotsVertical as IconDotsVertical,
 } from 'react-icons/tb';
+import TableMenu from '../DataTable/TableMenu';
 
 /**
  *
  */
-export function DataTableMenu () {
-  return (
-    <Menu shadow='md' width={200}>
-      <Menu.Target>
-        <ActionIcon variant='default'>
-          <IconDotsVertical />
-        </ActionIcon>
-      </Menu.Target>
+export function DataTableMenu() {
+  const menuItems = [
+    {
+      isLabel: true,
+      label: 'Account',
+    },
+    {
+      icon: <IconSettings style={{ width: rem(14), height: rem(14) }} />,
+      label: 'Account',
+      onClick: () => {/* implement account action */},
+    },
+    {
+      icon: <IconMessageCircle style={{ width: rem(14), height: rem(14) }} />,
+      label: 'Message',
+      onClick: () => {/* implement message action */},
+    },
+    {
+      divider: true,
+    },
+    {
+      isLabel: true,
+      label: 'Danger zone',
+    },
+    {
+      icon: <IconArrowsLeftRight style={{ width: rem(14), height: rem(14) }} />,
+      label: 'Update role',
+      onClick: () => {/* implement role update action */},
+    },
+    {
+      icon: <IconTrash style={{ width: rem(14), height: rem(14) }} />,
+      label: 'Delete account',
+      color: 'red',
+      onClick: () => {/* implement delete action */},
+    },
+  ];
 
-      <Menu.Dropdown>
-        <Menu.Label>Account</Menu.Label>
-        <Menu.Item
-          leftSection={
-            <IconSettings style={{ width: rem(14), height: rem(14) }} />
-          }
-        >
-          Account
-        </Menu.Item>
-        <Menu.Item
-          leftSection={
-            <IconMessageCircle style={{ width: rem(14), height: rem(14) }} />
-          }
-        >
-          Message
-        </Menu.Item>
-
-        <Menu.Divider />
-
-        <Menu.Label>Danger zone</Menu.Label>
-        <Menu.Item
-          leftSection={
-            <IconArrowsLeftRight style={{ width: rem(14), height: rem(14) }} />
-          }
-        >
-          Update role
-        </Menu.Item>
-        <Menu.Item
-          color='red'
-          leftSection={
-            <IconTrash style={{ width: rem(14), height: rem(14) }} />
-          }
-        >
-          Delete account
-        </Menu.Item>
-      </Menu.Dropdown>
-    </Menu>
-  );
+  return <TableMenu menuItems={menuItems} />;
 }

--- a/client/src/components/UsersDataTable/UserDataTableCell.jsx
+++ b/client/src/components/UsersDataTable/UserDataTableCell.jsx
@@ -44,7 +44,7 @@ export const UserDataTableCell = ({ type, value }) => {
         <Table.Td>
           <Checkbox
             checked={value.selected}
-            // onChange is a Mantine prop for the Checkbox component, improperly considers it a react event handler
+            // onChange is a Mantine prop for the Checkbox component, neostandard improperly considers it a react event handler
             // eslint-disable-next-line react/jsx-handler-names
             onChange={value.select}
           />

--- a/client/src/components/UsersDataTable/UserDataTableCell.jsx
+++ b/client/src/components/UsersDataTable/UserDataTableCell.jsx
@@ -23,7 +23,14 @@ export const UserDataTableCell = ({ type, value }) => {
             : 'yellow';
       return (
         <Table.Td>
-          <Badge color={color}>{value}</Badge>
+          <Badge color={color}>
+            <Text span visibleFrom="sm" fw={700} tt="capitalize" size="sm">
+              {value}
+            </Text>
+            <Text span hiddenFrom="sm" fw={700} tt="capitalize" size="sm">
+              {value[0]}
+            </Text>
+          </Badge>
         </Table.Td>
       );
     }
@@ -83,9 +90,36 @@ const UserRoleBadge = ({ value }) => {
       break;
   }
   return (
-    <Badge color={color}>
-      <Text fw={700} tt='capitalize' size='sm'>
-        {value.toLocaleLowerCase().replace('_', ' ')}
+    <Badge color={color} style={{ whiteSpace: 'nowrap', padding: '0.25rem 0.5rem' }}>
+      <Text
+        span
+        visibleFrom="sm"
+        fw={700}
+        tt="capitalize"
+        size="sm"
+        style={{
+          lineHeight: '1.2',
+          display: 'flex',
+          alignItems: 'center',
+          whiteSpace: 'nowrap'
+        }}
+      >
+        {value.toLowerCase().replace('_', ' ')}
+      </Text>
+      <Text
+        span
+        hiddenFrom="sm"
+        fw={700}
+        tt="capitalize"
+        size="sm"
+        style={{
+          lineHeight: '1.2',
+          display: 'flex',
+          alignItems: 'center',
+          padding: '0 2px'
+        }}
+      >
+        {value[0]}
       </Text>
     </Badge>
   );

--- a/client/src/components/UsersDataTable/UserDataTableCell.jsx
+++ b/client/src/components/UsersDataTable/UserDataTableCell.jsx
@@ -1,6 +1,7 @@
 import React from 'react';
 import PropTypes from 'prop-types';
 import { Badge, Checkbox, Table, Text } from '@mantine/core';
+import { humanize } from 'inflection';
 import { DataTableMenu } from './DataTableMenu';
 
 const userDataTableProps = {
@@ -104,7 +105,7 @@ const UserRoleBadge = ({ value }) => {
           whiteSpace: 'nowrap'
         }}
       >
-        {value.toLowerCase().replace('_', ' ')}
+        {humanize(value)}
       </Text>
       <Text
         span

--- a/client/src/components/UsersDataTable/UserDataTableCell.jsx
+++ b/client/src/components/UsersDataTable/UserDataTableCell.jsx
@@ -91,35 +91,14 @@ const UserRoleBadge = ({ value }) => {
       break;
   }
   return (
-    <Badge color={color} style={{ whiteSpace: 'nowrap', padding: '0.25rem 0.5rem' }}>
-      <Text
-        span
-        visibleFrom='sm'
-        fw={700}
-        tt='capitalize'
-        size='sm'
-        style={{
-          lineHeight: '1.2',
-          display: 'flex',
-          alignItems: 'center',
-          whiteSpace: 'nowrap'
-        }}
-      >
+    <Badge
+      color={color}
+      style={{ whiteSpace: 'nowrap', padding: '0.25rem 0.5rem' }}
+    >
+      <Text span visibleFrom='sm' fw={700} tt='capitalize' size='sm'>
         {humanize(value)}
       </Text>
-      <Text
-        span
-        hiddenFrom='sm'
-        fw={700}
-        tt='capitalize'
-        size='sm'
-        style={{
-          lineHeight: '1.2',
-          display: 'flex',
-          alignItems: 'center',
-          padding: '0 2px'
-        }}
-      >
+      <Text span hiddenFrom='sm' fw={700} tt='capitalize' size='sm'>
         {value[0]}
       </Text>
     </Badge>

--- a/client/src/components/UsersDataTable/UserDataTableCell.jsx
+++ b/client/src/components/UsersDataTable/UserDataTableCell.jsx
@@ -25,10 +25,10 @@ export const UserDataTableCell = ({ type, value }) => {
       return (
         <Table.Td>
           <Badge color={color}>
-            <Text span visibleFrom="sm" fw={700} tt="capitalize" size="sm">
+            <Text span visibleFrom='sm' fw={700} tt='capitalize' size='sm'>
               {value}
             </Text>
-            <Text span hiddenFrom="sm" fw={700} tt="capitalize" size="sm">
+            <Text span hiddenFrom='sm' fw={700} tt='capitalize' size='sm'>
               {value[0]}
             </Text>
           </Badge>
@@ -94,10 +94,10 @@ const UserRoleBadge = ({ value }) => {
     <Badge color={color} style={{ whiteSpace: 'nowrap', padding: '0.25rem 0.5rem' }}>
       <Text
         span
-        visibleFrom="sm"
+        visibleFrom='sm'
         fw={700}
-        tt="capitalize"
-        size="sm"
+        tt='capitalize'
+        size='sm'
         style={{
           lineHeight: '1.2',
           display: 'flex',
@@ -109,10 +109,10 @@ const UserRoleBadge = ({ value }) => {
       </Text>
       <Text
         span
-        hiddenFrom="sm"
+        hiddenFrom='sm'
         fw={700}
-        tt="capitalize"
-        size="sm"
+        tt='capitalize'
+        size='sm'
         style={{
           lineHeight: '1.2',
           display: 'flex',

--- a/client/src/components/UsersDataTable/UserDataTableCell.jsx
+++ b/client/src/components/UsersDataTable/UserDataTableCell.jsx
@@ -93,7 +93,7 @@ const UserRoleBadge = ({ value }) => {
   return (
     <Badge
       color={color}
-      style={{ whiteSpace: 'nowrap', padding: '0.25rem 0.5rem' }}
+      style={{ padding: '0.25rem 0.5rem' }}
     >
       <Text span visibleFrom='sm' fw={700} tt='capitalize' size='sm'>
         {humanize(value)}

--- a/client/src/components/UsersDataTable/UsersDataTable.jsx
+++ b/client/src/components/UsersDataTable/UsersDataTable.jsx
@@ -35,7 +35,7 @@ export const UserDataTable = ({ headers = [], rows = [] }) => {
       headers={headers}
       data={rows}
       renderRow={renderRow}
-      emptyStateMessage="No users found."
+      emptyStateMessage='No users found.'
     />
   );
 };

--- a/client/src/components/UsersDataTable/UsersDataTable.jsx
+++ b/client/src/components/UsersDataTable/UsersDataTable.jsx
@@ -1,63 +1,42 @@
-import React from 'react';
 import PropTypes from 'prop-types';
-import { Table } from '@mantine/core';
+import DataTable from '../DataTable/DataTable';
 import { UserDataTableCell } from './UserDataTableCell';
+import { Table } from '@mantine/core';
 
 const userDataTableProps = {
-  striped: PropTypes.bool,
-  highlightOnHover: PropTypes.bool,
-  withTableBorder: PropTypes.bool,
-  withColumnBorders: PropTypes.bool,
-  rows: PropTypes.arrayOf(
-    PropTypes.shape({
-      id: PropTypes.string.isRequired,
-    })
-  ),
   headers: PropTypes.arrayOf(
     PropTypes.shape({
       key: PropTypes.string.isRequired,
       text: PropTypes.node,
     })
   ),
+  rows: PropTypes.arrayOf(
+    PropTypes.shape({
+      id: PropTypes.string.isRequired,
+    })
+  ),
 };
 
-/**
- * Basic DataTable
- * @param {PropTypes.InferProps<typeof userDataTableProps>} props
- */
-export const UserDataTable = ({ headers = [], rows = [], ...rest }) => {
-  const formattedRows = rows.map((row) => {
-    return {
-      ...row,
-      cells: headers.map((header) => ({
-        key: header.key,
-        value: row[header.key],
-      })),
-    };
-  });
+export const UserDataTable = ({ headers = [], rows = [] }) => {
+  const renderRow = (row) => (
+    <Table.Tr key={row.id}>
+      {headers.map((header) => (
+        <UserDataTableCell
+          key={header.key}
+          type={header.key}
+          value={row[header.key]}
+        />
+      ))}
+    </Table.Tr>
+  );
+
   return (
-    <Table {...rest}>
-      <Table.Thead>
-        <Table.Tr>
-          {headers.map((header) => (
-            <Table.Th key={header.key}>{header.text}</Table.Th>
-          ))}
-        </Table.Tr>
-      </Table.Thead>
-      <Table.Tbody>
-        {formattedRows.map((row) => (
-          <Table.Tr key={row.id}>
-            {row.cells.map((cell) => (
-              <UserDataTableCell
-                key={cell.key}
-                type={cell.key}
-                value={cell.value}
-              />
-            ))}
-          </Table.Tr>
-        ))}
-      </Table.Tbody>
-    </Table>
+    <DataTable
+      headers={headers}
+      data={rows}
+      renderRow={renderRow}
+      emptyStateMessage="No users found."
+    />
   );
 };
 

--- a/client/src/pages/patients/LifelineAPI.js
+++ b/client/src/pages/patients/LifelineAPI.js
@@ -1,7 +1,6 @@
 const SERVER_BASE_URL = '/api/v1';
 
 export default class LifelineAPI {
-
   static async getUsers (query, page) {
     const response = await fetch(
       `${SERVER_BASE_URL}/users?user=${query}&page=${page}`, {

--- a/client/src/pages/patients/LifelineAPI.js
+++ b/client/src/pages/patients/LifelineAPI.js
@@ -1,6 +1,16 @@
 const SERVER_BASE_URL = '/api/v1';
 
 export default class LifelineAPI {
+
+  static async getUsers (query, page) {
+    const response = await fetch(
+      `${SERVER_BASE_URL}/users?user=${query}&page=${page}`, {
+        credentials: 'include',
+      }
+    );
+    return response;
+  }
+
   static async getHealthcareChoices (route, query) {
     if (route === 'hospital') {
       return this.getHospitals(query);

--- a/client/src/pages/patients/PatientTableRow.jsx
+++ b/client/src/pages/patients/PatientTableRow.jsx
@@ -32,7 +32,7 @@ const patientTableRowProps = {
  * Patient table row component
  * @param {PropTypes.InferProps<typeof patientTableRowProps>} props
  */
-export default function PatientTableRow({
+export default function PatientTableRow ({
   headers,
   patient,
   onDelete,
@@ -48,7 +48,7 @@ export default function PatientTableRow({
     {
       icon: <IconQrcode size={18} />,
       label: 'Reprint QR Code',
-      onClick: () => {/* implement QR code logic */},
+      onClick: () => { /* implement QR code logic */ },
     },
   ];
 

--- a/client/src/pages/patients/PatientTableRow.jsx
+++ b/client/src/pages/patients/PatientTableRow.jsx
@@ -1,14 +1,12 @@
 import PropTypes from 'prop-types';
-
 import { Link } from 'react-router';
-
-import { Table, Menu, ActionIcon } from '@mantine/core';
+import { Table } from '@mantine/core';
 import {
-  TbDotsVertical as IconDotsVertical,
   TbUser as IconUser,
   TbQrcode as IconQrcode,
   TbTrash as IconTrash,
 } from 'react-icons/tb';
+import TableMenu from '../../components/DataTable/TableMenu';
 
 const patientTableRowProps = {
   headers: PropTypes.arrayOf(
@@ -34,12 +32,35 @@ const patientTableRowProps = {
  * Patient table row component
  * @param {PropTypes.InferProps<typeof patientTableRowProps>} props
  */
-export default function PatientTableRow ({
+export default function PatientTableRow({
   headers,
   patient,
   onDelete,
   showDeleteMenu,
 }) {
+  const menuItems = [
+    {
+      icon: <IconUser size={18} />,
+      label: 'View/Edit',
+      to: `/patients/${patient.id}`,
+      component: Link,
+    },
+    {
+      icon: <IconQrcode size={18} />,
+      label: 'Reprint QR Code',
+      onClick: () => {/* implement QR code logic */},
+    },
+  ];
+
+  if (showDeleteMenu) {
+    menuItems.push({
+      icon: <IconTrash size={18} />,
+      label: 'Delete',
+      color: 'red',
+      onClick: () => onDelete({ id: patient.id, name: patient.name }),
+    });
+  }
+
   return (
     <Table.Tr key={patient.id}>
       {headers.map((header) => (
@@ -48,38 +69,7 @@ export default function PatientTableRow ({
         </Table.Td>
       ))}
       <Table.Td>
-        <Menu shadow='md'>
-          <Menu.Target>
-            <ActionIcon variant='subtle' color='gray'>
-              <IconDotsVertical size={18} />
-            </ActionIcon>
-          </Menu.Target>
-          <Menu.Dropdown>
-            <Menu.Item
-              leftSection={<IconUser size={18} />}
-              component={Link}
-              to={`/patients/${patient.id}`}
-            >
-              View/Edit
-            </Menu.Item>
-            <Menu.Item leftSection={<IconQrcode size={18} />}>
-              Reprint QR Code
-            </Menu.Item>
-            {showDeleteMenu && (
-              <Menu.Item
-                leftSection={<IconTrash size={18} />}
-                color='red'
-                onClick={() =>
-                  onDelete({
-                    id: patient.id,
-                    name: patient.name,
-                  })}
-              >
-                Delete
-              </Menu.Item>
-            )}
-          </Menu.Dropdown>
-        </Menu>
+        <TableMenu menuItems={menuItems} />
       </Table.Td>
     </Table.Tr>
   );

--- a/client/src/pages/patients/PatientsTable.jsx
+++ b/client/src/pages/patients/PatientsTable.jsx
@@ -9,6 +9,7 @@ import classes from './Patients.module.css';
 import Context from '../../Context';
 
 import PatientTableRow from './PatientTableRow';
+import DataTable from '../../components/DataTable/DataTable';
 
 const patientTableProps = {
   headers: PropTypes.arrayOf(
@@ -73,17 +74,8 @@ export default function PatientsTable ({ headers, data }) {
     close();
   };
 
-  const emptyStateRow = useMemo(
-    () => (
-      <Table.Tr>
-        <Table.Td colSpan={headers.length}>No patients found.</Table.Td>
-      </Table.Tr>
-    ),
-    [headers.length]
-  );
-
-  const patientRows = useMemo(() => {
-    return data?.map((patient) => (
+  const renderRow = useCallback(
+    (patient) => (
       <PatientTableRow
         key={patient.id}
         patient={patient}
@@ -91,32 +83,18 @@ export default function PatientsTable ({ headers, data }) {
         onDelete={showDeleteConfirmation}
         showDeleteMenu={user?.role === 'ADMIN'}
       />
-    ));
-  }, [data, headers, user.role, showDeleteConfirmation]);
+    ),
+    [headers, user?.role, showDeleteConfirmation]
+  );
 
   return (
     <>
-      <Paper withBorder className={classes.tableWrapper}>
-        <Table.ScrollContainer minWidth={500} type='native'>
-          <Table
-            stickyHeader
-            highlightOnHover
-            verticalSpacing='lg'
-            classNames={{ table: classes.table }}
-          >
-            <Table.Thead>
-              <Table.Tr>
-                {headers.map((header) => (
-                  <Table.Th key={header.key}>{header.text}</Table.Th>
-                ))}
-              </Table.Tr>
-            </Table.Thead>
-            <Table.Tbody>
-              {data?.length > 0 ? patientRows : emptyStateRow}
-            </Table.Tbody>
-          </Table>
-        </Table.ScrollContainer>
-      </Paper>
+      <DataTable
+        headers={headers}
+        data={data}
+        renderRow={renderRow}
+        emptyStateMessage="No patients found."
+      />
       <Modal
         opened={opened}
         onClose={close}

--- a/client/src/pages/patients/PatientsTable.jsx
+++ b/client/src/pages/patients/PatientsTable.jsx
@@ -1,7 +1,7 @@
 import PropTypes from 'prop-types';
 
-import { useState, useContext, useMemo, useCallback } from 'react';
-import { Paper, Table, Modal, Button, Text } from '@mantine/core';
+import { useState, useContext, useCallback } from 'react';
+import { Modal, Button, Text } from '@mantine/core';
 import { useDisclosure } from '@mantine/hooks';
 import { useDeletePatient } from './useDeletePatient';
 import { notifications } from '@mantine/notifications';

--- a/client/src/pages/patients/PatientsTable.jsx
+++ b/client/src/pages/patients/PatientsTable.jsx
@@ -93,7 +93,7 @@ export default function PatientsTable ({ headers, data }) {
         headers={headers}
         data={data}
         renderRow={renderRow}
-        emptyStateMessage="No patients found."
+        emptyStateMessage='No patients found.'
       />
       <Modal
         opened={opened}

--- a/client/src/pages/users/Users.jsx
+++ b/client/src/pages/users/Users.jsx
@@ -12,9 +12,8 @@ import {
   Pagination,
   TextInput,
 } from '@mantine/core';
-import { useDisclosure } from '@mantine/hooks';
+import { useDisclosure, useDebouncedCallback } from '@mantine/hooks';
 import { useUsers } from './useUsers';
-import { useDebouncedCallback } from '@mantine/hooks';
 
 import classes from './Users.module.css';
 import { UserDataTable } from '../../components/UsersDataTable/UsersDataTable';
@@ -37,7 +36,7 @@ function Users () {
   const navigate = useNavigate();
   const [opened, { open, close }] = useDisclosure(false);
   const [inputValue, setInputValue] = useState('');
-  
+
   const { users, isFetching, page, pages, setPage, setSearch } = useUsers();
 
   const handleSearch = useDebouncedCallback((query) => {

--- a/client/src/pages/users/Users.jsx
+++ b/client/src/pages/users/Users.jsx
@@ -2,7 +2,6 @@ import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { TbSearch as IconSearch } from 'react-icons/tb';
 import {
-  Badge,
   Box,
   Button,
   Container,

--- a/client/src/pages/users/Users.jsx
+++ b/client/src/pages/users/Users.jsx
@@ -10,6 +10,7 @@ import {
   LoadingOverlay,
   Pagination,
   TextInput,
+  Text,
 } from '@mantine/core';
 import { useDisclosure, useDebouncedCallback } from '@mantine/hooks';
 import { useUsers } from './useUsers';
@@ -46,7 +47,9 @@ function Users () {
     <Container>
       <InviteModal opened={opened} close={close} />
       <div className={classes.header}>
-        <h4>Members</h4>
+        <Text fw={600} size='xl' mr='md'>
+          Members
+        </Text>
         <Group className={classes.actions}>
           <TextInput
             leftSectionPointerEvents='none'

--- a/client/src/pages/users/Users.jsx
+++ b/client/src/pages/users/Users.jsx
@@ -1,4 +1,4 @@
-import React, { useState } from 'react';
+import { useState } from 'react';
 import { useNavigate } from 'react-router';
 import { TbSearch as IconSearch } from 'react-icons/tb';
 import {

--- a/client/src/pages/users/Users.module.css
+++ b/client/src/pages/users/Users.module.css
@@ -2,6 +2,7 @@
   border-radius: 12px;
   overflow: hidden;
   margin: 0 2rem;
+  margin-bottom: var(--mantine-spacing-xs);
 }
 
 .header {

--- a/client/src/pages/users/Users.module.css
+++ b/client/src/pages/users/Users.module.css
@@ -1,9 +1,6 @@
 .datatableWrapper {
   border-radius: 12px;
   overflow: hidden;
-  border: calc(0.0625rem * var(--mantine-scale)) solid
-    var(--mantine-color-gray-3);
-
   margin: 0 2rem;
 }
 

--- a/client/src/pages/users/Users.module.css
+++ b/client/src/pages/users/Users.module.css
@@ -8,7 +8,7 @@
 .header {
   display: flex;
   justify-content: space-between;
-  margin: 0 1rem;
+  margin: 1rem 1rem;
 }
 
 .header > * {

--- a/client/src/pages/users/useUsers.jsx
+++ b/client/src/pages/users/useUsers.jsx
@@ -47,8 +47,6 @@ export function useUsers() {
     },
   });
 
-  console.log(data);
-
   return {
     users: data?.users,
     headers: USER_TABLE_HEADERS,

--- a/client/src/pages/users/useUsers.jsx
+++ b/client/src/pages/users/useUsers.jsx
@@ -1,0 +1,64 @@
+import { useState } from 'react';
+import { useQuery } from '@tanstack/react-query';
+import LifelineAPI from '../patients/LifelineAPI';
+
+const USER_TABLE_HEADERS = [
+  { key: 'name', text: 'Name' },
+  { key: 'status', text: 'Status' },
+  { key: 'role', text: 'Role' },
+  { key: 'languages', text: 'Other languages' },
+  { key: 'email', text: 'Email address' },
+  { key: 'organization', text: 'Organization' },
+  { key: 'more', text: '' },
+];
+
+export function useUsers() {
+  const [search, setSearch] = useState('');
+  const [page, setPage] = useState(1);
+  const [pendingMembers, setPendingMembers] = useState(0);
+  
+  const { data, isFetching } = useQuery({
+    queryKey: ['users', search, page],
+    queryFn: async () => {
+      const res = await LifelineAPI.getUsers(search, page);
+      if (!res.ok) {
+        throw new Error('Failed to fetch users.');
+      }
+      const users = await res.json();
+      const pages = +res.headers.get('X-Total-Pages');
+      
+      const pendingUsers = users.filter(
+        (user) => user.approvedAt.length === 0 && user.rejectedAt.length === 0
+      );
+      setPendingMembers(pendingUsers.length);
+
+      const transformedUsers = users.map((user) => ({
+        ...user,
+        name: user.firstName + ' ' + user.lastName,
+        status:
+          user.rejectedAt.length > 0
+            ? 'Rejected'
+            : user.approvedAt.length > 0
+              ? 'Active'
+              : 'Pending',
+      }));
+
+      return { users: transformedUsers, pages };
+    },
+  });
+
+  console.log(data);
+
+  return {
+    users: data?.users,
+    headers: USER_TABLE_HEADERS,
+    search,
+    setSearch,
+    page,
+    setPage,
+    pages: data?.pages,
+    isFetching,
+    pendingMembers,
+  };
+}
+

--- a/client/src/pages/users/useUsers.jsx
+++ b/client/src/pages/users/useUsers.jsx
@@ -12,11 +12,11 @@ const USER_TABLE_HEADERS = [
   { key: 'more', text: '' },
 ];
 
-export function useUsers() {
+export function useUsers () {
   const [search, setSearch] = useState('');
   const [page, setPage] = useState(1);
   const [pendingMembers, setPendingMembers] = useState(0);
-  
+
   const { data, isFetching } = useQuery({
     queryKey: ['users', search, page],
     queryFn: async () => {
@@ -26,7 +26,7 @@ export function useUsers() {
       }
       const users = await res.json();
       const pages = +res.headers.get('X-Total-Pages');
-      
+
       const pendingUsers = users.filter(
         (user) => user.approvedAt.length === 0 && user.rejectedAt.length === 0
       );
@@ -59,4 +59,3 @@ export function useUsers() {
     pendingMembers,
   };
 }
-


### PR DESCRIPTION
Closes #181.

This PR creates a new reusable table component to be shared between `Patients` and `Members`. The styling of this shared component is based on the styling from the `Patients` table since that matched the designs more closely. 

<p align="center">
  <img src="https://github.com/user-attachments/assets/f7621671-76b0-40f9-8b24-215fe0e045bc" width="45%" />
  <img src="https://github.com/user-attachments/assets/cb514d50-0235-42a6-b09b-2ac25342d970" width="45%" />
</p>

A separate PR needs to made to allow for querying users the way that querying patients works and for making the header of Users to be responsive on smaller screens