### PR TITLE
Header of patients list showing when side tab is open. #173

### DIFF
--- a/client/src/components/DataTable/DataTable.jsx
+++ b/client/src/components/DataTable/DataTable.jsx
@@ -38,7 +38,6 @@ export default function DataTable ({
     <Paper withBorder className={classes.tableWrapper}>
       <Table.ScrollContainer minWidth={500} type='native'>
         <Table
-          stickyHeader
           highlightOnHover
           verticalSpacing='lg'
           classNames={{ table: classes.table }}

--- a/client/src/components/UsersDataTable/DataTableMenu.jsx
+++ b/client/src/components/UsersDataTable/DataTableMenu.jsx
@@ -14,6 +14,7 @@ import TableMenu from '../DataTable/TableMenu';
 export function DataTableMenu () {
   const menuItems = [
     {
+      icon: <></>,
       isLabel: true,
       label: 'Account',
     },
@@ -28,9 +29,13 @@ export function DataTableMenu () {
       onClick: () => { /* implement message action */ },
     },
     {
+      icon: <></>,
+      label: '',
       divider: true,
     },
     {
+      icon: <></>,
+      label: '',
       isLabel: true,
       label: 'Danger zone',
     },

--- a/client/src/components/UsersDataTable/DataTableMenu.jsx
+++ b/client/src/components/UsersDataTable/DataTableMenu.jsx
@@ -35,7 +35,6 @@ export function DataTableMenu () {
     },
     {
       icon: <></>,
-      label: '',
       isLabel: true,
       label: 'Danger zone',
     },


### PR DESCRIPTION
Fixed table header from leaking into the navbar.
Added node elements to required props in Datatable.

<img width="213" alt="image" src="https://github.com/user-attachments/assets/680e6bf9-c174-4882-992b-e506bd9eafe8" />
