### PR TITLE
[Closes #153] Scale font sizes via Mantine Theme

### DIFF
--- a/client/src/theme.js
+++ b/client/src/theme.js
@@ -1,3 +1,5 @@
 import { createTheme } from '@mantine/core';
 
-export default createTheme({});
+export default createTheme({
+  scale: 1.2,
+});


### PR DESCRIPTION
Closes #153.

This PR utilizes the `scale` property from the [Mantine theme object](https://mantine.dev/theming/theme-object/) to uniformly scale the size of all the text in the app. 

<div align="center">
  <p>Before vs After:</p>
  <img src="https://github.com/user-attachments/assets/eeef3067-b87a-471c-b8b2-2e2090fd1e43" width="40%" /> 
  <img src="https://github.com/user-attachments/assets/c0332086-8c2e-4f45-9fce-a4462533d759" width="40%" />
</div>