### PR TITLE
[Fixes #203] Resolve Patient DOB Bug

### DIFF
--- a/client/src/pages/patients/register/PatientRegistration.jsx
+++ b/client/src/pages/patients/register/PatientRegistration.jsx
@@ -178,7 +178,7 @@ export default function PatientRegistration () {
         lastName,
         gender,
         language,
-        dateOfBirth: new Date(dateOfBirth),
+        dateOfBirth: dateOfBirth,
       };
       const contactData = {
         firstName: emergencyContact?.firstName || '',

--- a/client/src/pages/patients/register/PatientRegistration.jsx
+++ b/client/src/pages/patients/register/PatientRegistration.jsx
@@ -178,7 +178,7 @@ export default function PatientRegistration () {
         lastName,
         gender,
         language,
-        dateOfBirth: dateOfBirth,
+        dateOfBirth,
       };
       const contactData = {
         firstName: emergencyContact?.firstName || '',

--- a/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
+++ b/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
@@ -4,6 +4,7 @@ import { Accordion, TextInput, NativeSelect, Stack, InputBase } from '@mantine/c
 import { TbCircleCheck as IconCircleCheck } from 'react-icons/tb';
 import { IMaskInput } from 'react-imask';
 import { useTranslation } from 'react-i18next';
+import dayjs from 'dayjs';
 
 import MedicalDataSearch from './inputs/MedicalDataSearch';
 import HealthcareChoicesSearch from './inputs/HealthcareChoicesSearch';
@@ -112,7 +113,7 @@ export default function PatientRegistrationAccordion ({
                 type='date'
                 label='Date of Birth'
                 withAsterisk
-                max={new Date().toLocaleDateString('en-CA')} // need to use en-CA to get the correct format for HTML date input
+                max={dayjs().format('YYYY-MM-DD')}
                 key={form.key('patientData.dateOfBirth')}
                 {...form.getInputProps('patientData.dateOfBirth')}
               />

--- a/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
+++ b/client/src/pages/patients/register/PatientRegistrationAccordion.jsx
@@ -111,11 +111,8 @@ export default function PatientRegistrationAccordion ({
               <TextInput
                 type='date'
                 label='Date of Birth'
-                valueFormat='YYYY-MM-DD'
-                placeholder='YYYY-MM-DD'
-                defaultLevel='decade'
-                maxDate={new Date()}
                 withAsterisk
+                max={new Date().toLocaleDateString('en-CA')} // need to use en-CA to get the correct format for HTML date input
                 key={form.key('patientData.dateOfBirth')}
                 {...form.getInputProps('patientData.dateOfBirth')}
               />

--- a/client/src/pages/patients/usePatients.jsx
+++ b/client/src/pages/patients/usePatients.jsx
@@ -1,6 +1,7 @@
 import { useState } from 'react';
 import { useQuery } from '@tanstack/react-query';
 import LifelineAPI from './LifelineAPI';
+import dayjs from 'dayjs';
 
 const PATIENT_TABLE_HEADERS = [
   { key: 'name', text: 'Name' },
@@ -14,14 +15,6 @@ const PATIENT_TABLE_HEADERS = [
 const formatName = (entry) => {
   const formattedName = `${entry.firstName}${entry.middleName ? ` ${entry.middleName}` : ''} ${entry.lastName}`;
   return formattedName.trim() ? formattedName : '-';
-};
-
-const formatDate = (date) => {
-  return new Date(date).toLocaleDateString(undefined, {
-    month: 'long',
-    day: 'numeric',
-    year: 'numeric',
-  });
 };
 
 /**
@@ -75,9 +68,9 @@ export function usePatients () {
         id: patient.id,
         name: formatName(patient),
         createdBy: formatName(patient.createdBy),
-        createdAt: formatDate(patient.createdAt),
-        updatedBy: formatName(patient.createdBy),
-        updatedAt: formatDate(patient.updatedAt),
+        createdAt: dayjs(patient.createdAt).format('MMMM D, YYYY'),
+        updatedBy: formatName(patient.updatedBy),
+        updatedAt: dayjs(patient.updatedAt).format('MMMM D, YYYY'),
       })),
       pages: res.pages,
     }),


### PR DESCRIPTION
Fixes #203.

As described in the issue, the date of birth field was not persisting values correctly when navigating between sections. This was happening because:
1. The date input is now using a `TextInput`, whereas before it was using a `DateInput`
  - When `DateInput` was being used, the DOB value from the server was converted into a `date` object to be compatible with the format expected with this input field (i.e. `new Date(dateOfBirth)`) but this is no longer necessary
2. This meant that the date format handling wasn't consistent between server data and input requirements due to the change in input type formats

Therefore, to resolve this issue the DOB value when populating the form with the DOB data from the server has to be kept as a `string` rather than converting it into a `date` object. 

Some additional key changes:
- Removed the props that were necessary for `DateInput` but are no longer valid for `TextInput` to resolve console warnings
- Set the max date format with `dayjs` to match the format that the HTML date input expects. However iOS Safari doesn't support the `max` attribute as seen from many online discussions like this [one](https://developer.apple.com/forums/thread/678601)


https://github.com/user-attachments/assets/11862316-20d3-4611-91e7-ab25bb916b0d



