### PR TITLE
[Fix #206] Update conditional rendering for contact name

### DIFF
--- a/client/src/pages/patients/patient-details/components/ContactInfo.jsx
+++ b/client/src/pages/patients/patient-details/components/ContactInfo.jsx
@@ -33,8 +33,8 @@ export default function ContactInfo ({ emergencyContact, physician }) {
             <div className={classes.contactRow}>
               <Text className={classes.boldText}>Name</Text>
               <Text>
-                {emergencyContact
-                  ? `${emergencyContact?.firstName} ${emergencyContact?.lastName}`
+                {(emergencyContact?.firstName || emergencyContact?.lastName)
+                  ? `${emergencyContact?.firstName || ''} ${emergencyContact?.middleName || ''} ${emergencyContact?.lastName || ''}`
                   : '-'}
               </Text>
             </div>


### PR DESCRIPTION
Fixes #206

This PR updates the conditional logic used to determine when to display an emergency contact's name values or a dash (when null/undefined/empty string).

![Conditional Name Display](https://github.com/user-attachments/assets/f12ca132-7dfb-472d-b269-2ee35d9eb0c1)
