### PR TITLE
[Closes #233] Sort patients by `updatedAt`

### DIFF
--- a/server/routes/api/v1/patients/list.js
+++ b/server/routes/api/v1/patients/list.js
@@ -133,7 +133,7 @@ export default async function (fastify) {
       const options = {
         page,
         perPage,
-        orderBy: [{ firstName: 'asc' }, { lastName: 'asc' }],
+        orderBy: [{ updatedAt: 'desc' }],
         where: whereClause,
         include: {
           createdBy: true,


### PR DESCRIPTION
Closes #233

This PR changes the sort order of the patients list API, and therefore the patients table, by the `updatedAt` field. This makes it so the Patients Table page shows the list of patients in descending order. 

<div>
  <b>Before:</b>
  <img src="https://github.com/user-attachments/assets/e4fb15e7-8f3f-4e6a-91b0-f380b9b6fbab" />
  <b>After:</b>
  <img src="https://github.com/user-attachments/assets/52e7538a-4b94-4a81-920a-057862605df1" />
</div>
