### PR TITLE
[Closes #232] Prevent volunteer level users from seeing physicians page

### DIFF
--- a/client/src/components/Sidebar/Sidebar.jsx
+++ b/client/src/components/Sidebar/Sidebar.jsx
@@ -16,7 +16,6 @@ import classes from './Sidebar.module.css';
 import { useAuthorization } from '../../hooks/useAuthorization';
 import { ROLES } from '../../routes';
 
-// Define all navigation items with role requirements
 const allNavigationItems = {
   adminPanel: {
     label: 'Admin panel',
@@ -26,7 +25,7 @@ const allNavigationItems = {
         label: 'Dashboard',
         icon: <LuLayoutDashboard className={classes.navbar__icon} />,
         href: '/',
-        minRole: 'FIRST_RESPONDER', // All roles can see dashboard
+        minRole: 'FIRST_RESPONDER',
       },
     ],
   },
@@ -43,19 +42,19 @@ const allNavigationItems = {
         label: 'Members',
         href: '/users',
         icon: <FiUsers className={classes.navbar__icon} />,
-        minRole: 'ADMIN', // Only admins can see Members
+        minRole: 'ADMIN',
       },
       {
         label: 'Patients',
         href: '/patients',
         icon: <TbHeartHandshake className={classes.navbar__icon} />,
-        minRole: 'STAFF', // Staff and above can see Patients
+        minRole: 'STAFF',
       },
       {
         label: 'Physicians',
         href: '/physicians',
         icon: <TbStethoscope className={classes.navbar__icon} />,
-        minRole: 'STAFF', // Staff and above can see Physicians
+        minRole: 'STAFF',
       },
     ],
   },
@@ -97,13 +96,11 @@ export function Sidebar ({ toggleSidebar }) {
     await handleLogout();
   }
 
-  // Helper function to check if a user has sufficient permissions
   const hasPermission = (minRole) => {
     if (!user || !user.role) return false;
     return ROLES.indexOf(user.role) >= ROLES.indexOf(minRole);
   };
 
-  // Filter navigation sections based on user role
   const filteredSections = [
     {
       ...allNavigationItems.adminPanel,

--- a/client/src/routes.jsx
+++ b/client/src/routes.jsx
@@ -35,7 +35,7 @@ export const ROLES = ['FIRST_RESPONDER', 'VOLUNTEER', 'STAFF', 'ADMIN'];
 // these are routes that require authentication and authorization by role
 export const AUTH_ROUTES = [
   ['ADMIN', ['users', 'users/pending']],
-  ['STAFF', ['patients/generate', 'patients']],
+  ['STAFF', ['patients/generate', 'patients', 'physicians']],
   ['VOLUNTEER', ['patients/:patientId/edit']],
   ['FIRST_RESPONDER', ['dashboard', 'patients/:patientId']],
 ];


### PR DESCRIPTION
Closes #232 

This PR changes the authorization level of the physicians page to be at least a `staff` level user.  In addition, the Sidebar component is updated to conditionally show items based on user types. 

<div align="center">
  <p>Before vs After:</p>
  <img src="https://github.com/user-attachments/assets/dd0e97b4-60e2-4449-9c86-b8a2a99d2d37" width="40%" /> 
  <img src="https://github.com/user-attachments/assets/b99d16e5-9672-4cbd-af64-5a1a69d42a07" width="40%" />
</div>